### PR TITLE
chore: remove frontend-lib-content-components from workflow [FC-0062]

### DIFF
--- a/.github/workflows/extract-translation-source-files.yml
+++ b/.github/workflows/extract-translation-source-files.yml
@@ -83,7 +83,6 @@ jobs:
               'frontend-app-support-tools',
               'frontend-component-footer',
               'frontend-component-header',
-              'frontend-lib-content-components',
               'frontend-lib-special-exams',
               'frontend-platform',
               'paragon',


### PR DESCRIPTION
We've moved [frontend-lib-content-components](https://github.com/openedx/frontend-lib-content-components) into [frontend-app-course-authoring](https://github.com/openedx/frontend-app-course-authoring/), so we don't need to extract translations from content-components any more.

Related PR: https://github.com/openedx/frontend-app-course-authoring/pull/1208